### PR TITLE
feat: Discord OAuth2 integration

### DIFF
--- a/API.md
+++ b/API.md
@@ -177,3 +177,23 @@ with a null team property.
     "team": null
 }
 ```
+
+
+### `GET /api/v1/discord?code=[...]&state=[...]`
+
+Used to identify users. Once users have authenticated with Discord, they are redirected here.
+
+The `code` query parameter is provided by the Discord OAuth2 system.
+
+The `state` query parameter stores the user's hs_auth ID to identify them on that service. The state is also used to verify that the request originated from the HackerSuite services.
+
+The user's Discord account is linked to their HackerSuite account, and the user is added to the Hackathon guild.
+
+If all of this happens successfully, the API responds like so:
+
+**Response (200):**
+```js
+{
+    "message": "ok"
+}
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,27 @@
       "integrity": "sha512-1dVNHT76Uu5N3eJNTYcvxee+jzX4Z9lfciqRRHCU27ihbUcYi+iSc2iml5Ke1LXe1SyJCLA0+14Jh4tXJgOppA==",
       "dev": true
     },
+    "@spectacles/rest": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@spectacles/rest/-/rest-0.6.1.tgz",
+      "integrity": "sha512-to0PJo1ebuqHUqqTDW0XXo3XzbFcybaNkTvrfno6yu76Vmiu2c2rKmCzIovmfPBpfc0OuLfNplBdDFUBzuVafA==",
+      "requires": {
+        "form-data": "^2.5.0",
+        "node-fetch": "^2.6.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
+          "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.6",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
+    },
     "@types/body-parser": {
       "version": "1.19.0",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.0.tgz",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "@types/express": "^4.17.3",
     "@types/node-fetch": "^2.5.5",
     "@unicsmcr/hs_auth_client": "^1.2.1",
+    "axios": "^0.19.2",
     "express": "^4.17.1",
     "form-data": "^3.0.0",
     "node-fetch": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     }
   },
   "dependencies": {
+    "@spectacles/rest": "^0.6.1",
     "@types/express": "^4.17.3",
     "@types/node-fetch": "^2.5.5",
     "@unicsmcr/hs_auth_client": "^1.2.1",

--- a/src/HackathonAPI.ts
+++ b/src/HackathonAPI.ts
@@ -1,5 +1,5 @@
 import 'reflect-metadata';
-import * as express from 'express';
+import express from 'express';
 import { UserController, TeamController, DiscordController } from './controllers';
 import RouteHandler, { ExpressHandler } from './RouteHandler';
 import { UsersRoute, UserRoute, TeamsRoute, TeamRoute, DiscordRoute } from './routes';

--- a/src/HackathonAPI.ts
+++ b/src/HackathonAPI.ts
@@ -1,8 +1,8 @@
 import 'reflect-metadata';
 import * as express from 'express';
-import { UserController, TeamController } from './controllers';
+import { UserController, TeamController, DiscordController } from './controllers';
 import RouteHandler, { ExpressHandler } from './RouteHandler';
-import { UsersRoute, UserRoute, TeamsRoute, TeamRoute } from './routes';
+import { UsersRoute, UserRoute, TeamsRoute, TeamRoute, DiscordRoute } from './routes';
 import { createConnection, ConnectionOptions, Connection } from 'typeorm';
 import { User } from './entities/User';
 import { Team } from './entities/Team';
@@ -21,11 +21,20 @@ export interface HackathonAPIOptions {
 		base: pino.Logger;
 		api: pino.Logger;
 	};
+	discord: {
+		hmacKey: string;
+		clientId: string;
+		clientSecret: string;
+		redirectUri: string;
+		guildId: string;
+		botToken: string;
+	};
 }
 
 interface Controllers {
 	user: UserController;
 	team: TeamController;
+	discord: DiscordController;
 }
 
 const VERBS: (keyof express.Router & keyof RouteHandler)[] = [
@@ -49,7 +58,8 @@ export default class HackathonAPI {
 
 		this.controllers = {
 			user: new UserController(this),
-			team: new TeamController(this)
+			team: new TeamController(this),
+			discord: new DiscordController(this)
 		};
 
 		this.handlers = [];
@@ -79,6 +89,7 @@ export default class HackathonAPI {
 			this.addRoute(new UserRoute(this));
 			this.addRoute(new TeamsRoute(this));
 			this.addRoute(new TeamRoute(this));
+			this.addRoute(new DiscordRoute(this));
 			this.express.listen(this.options.api.port, resolve);
 			this.express.on('error', err => {
 				reject(err);

--- a/src/controllers/DiscordController.ts
+++ b/src/controllers/DiscordController.ts
@@ -1,0 +1,95 @@
+import HackathonAPI from '../HackathonAPI';
+import { createHmac } from 'crypto';
+import axios from 'axios';
+import { stringify } from 'querystring';
+
+const API_BASE = 'https://discordapp.com/api/v6';
+
+interface TokenResponse {
+	access_token: string;
+	token_type: string;
+	expires_in: number;
+	refresh_token: string;
+	scope: string;
+}
+
+// not a full user, only properties we're interested in
+// see https://discordapp.com/developers/docs/resources/user#user-object
+interface DiscordUser {
+	id: string;
+	locale: string;
+}
+
+export interface APITeam {
+	authId: string;
+	name: string;
+	creator: string;
+	teamNumber: number;
+}
+
+export class DiscordController {
+	private readonly api: HackathonAPI;
+
+	public constructor(api: HackathonAPI) {
+		this.api = api;
+	}
+
+	public async processOAuth2(code: string, state: string) {
+		const authId = this.validateState(state);
+		const accessToken = await this.getAccessToken(code);
+		const user = await this.fetchUserDetails(accessToken);
+		await this.api.controllers.user.saveUser(user.id, authId);
+		await this.addUserToGuild(accessToken, user.id);
+	}
+
+	private async fetchUserDetails(accessToken: string) {
+		const res = await axios.get(`${API_BASE}/users/@me`, {
+			headers: {
+				Authorization: `Bearer ${accessToken}`
+			}
+		});
+		return res.data as DiscordUser;
+	}
+
+	private addUserToGuild(accessToken: string, userId: string) {
+		return axios.put(`${API_BASE}/guilds/${this.api.options.discord.guildId}/members/${userId}`,
+			{
+				access_token: accessToken
+			},
+			{
+				headers: {
+					Authorization: `Bot ${this.api.options.discord.botToken}`
+				}
+			});
+	}
+
+	private async getAccessToken(code: string) {
+		const res = await axios.post(`${API_BASE}/oauth2/token`, stringify({
+			client_id: this.api.options.discord.clientId,
+			client_secret: this.api.options.discord.clientSecret,
+			grant_type: 'authorization_code',
+			code,
+			redirect_uri: this.api.options.discord.redirectUri,
+			scope: 'identify guilds.join'
+		}));
+		const data = res.data as TokenResponse;
+		return data.access_token;
+	}
+
+	/**
+	 * Validates the state given back to us by Discord. This is done to check that it actually
+	 * comes from the hs system, and not some 3rd party. The state given is base64-encoded.
+	 * When decoded, it contains the authId and an hmac of the authId joined by a colon.
+	 * If the hmac is deemed to be valid, then this will return the authId, otherwise an
+	 * error will be thrown.
+	 */
+	private validateState(state: string) {
+		const [authId, givenHash] = Buffer.from(state, 'base64').toString('utf8').split(':');
+		if (!authId || !givenHash) throw new Error('Invalid state');
+		const hash = createHmac('sha256', this.api.options.discord.hmacKey)
+			.update(authId)
+			.digest('base64');
+		if (hash !== givenHash) throw new Error('State is not authentic');
+		return authId;
+	}
+}

--- a/src/controllers/index.ts
+++ b/src/controllers/index.ts
@@ -1,2 +1,3 @@
 export { UserController } from './UserController';
 export { TeamController } from './TeamController';
+export { DiscordController } from './DiscordController';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import HackathonAPI, { HackathonAPIOptions } from './HackathonAPI';
-import * as pino from 'pino';
+import pino from 'pino';
 const config = require('../data/config.json') as HackathonAPIOptions;
 
 const baseLogger = pino();

--- a/src/routes/DiscordRoute.ts
+++ b/src/routes/DiscordRoute.ts
@@ -1,0 +1,26 @@
+import RouteHandler from '../RouteHandler';
+import HackathonAPI from '../HackathonAPI';
+import { Request, Response } from 'express';
+
+interface QueryParams {
+	code?: string;
+	state?: string;
+}
+
+export class DiscordRoute implements RouteHandler {
+	private readonly api: HackathonAPI;
+	public constructor(api: HackathonAPI) {
+		this.api = api;
+	}
+
+	public getRoute() {
+		return '/discord';
+	}
+
+	public async get(req: Request, res: Response) {
+		const { code, state } = req.query as QueryParams;
+		if (!code || !state) return res.status(400).json({ message: 'Missing query parameters' });
+		await this.api.controllers.discord.processOAuth2(code, state);
+		res.json({ message: 'ok' });
+	}
+}

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -2,3 +2,4 @@ export { UsersRoute } from './UsersRoute';
 export { UserRoute } from './UserRoute';
 export { TeamsRoute } from './TeamsRoute';
 export { TeamRoute } from './TeamRoute';
+export { DiscordRoute } from './DiscordRoute';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,7 +23,10 @@
 		"allowSyntheticDefaultImports": true,
 		"pretty": true,
 		"experimentalDecorators": true,
-		"emitDecoratorMetadata": true
+		"emitDecoratorMetadata": true,
+		"skipLibCheck": true,
+		"esModuleInterop": true,
+		"resolveJsonModule": true
 	},
 	"exclude": [
 		"src/**/*.test.ts",


### PR DESCRIPTION
Resolves #1 

This allows users to use the Discord OAuth2 service to identify themselves quickly. This will also add them to the Hackathon server - this means we don't have to use invites, and can assume that all users on the server are already identified.

As a security measure, the OAuth2 `state` parameter also contains an HMAC to ensure that the request originated from `hs_hub`.