### PR TITLE
feat: improved errors + welcome channel URL

### DIFF
--- a/src/HackathonAPI.ts
+++ b/src/HackathonAPI.ts
@@ -123,7 +123,7 @@ export default class HackathonAPI {
 			});
 		} catch (error) {
 			const id = Date.now();
-			res.status(500).json({ error: `A server error occurred (id: ${id})` });
+			res.status(500).json({ error: `A server error occurred (id: ${id})`, message: error.message });
 			this.options.loggers.api.error({
 				method: req.method,
 				route: req.url,

--- a/src/controllers/DiscordResourceController.ts
+++ b/src/controllers/DiscordResourceController.ts
@@ -16,6 +16,12 @@ export class DiscordResourceController {
 		return this.api.db.getRepository(DiscordResource).findOneOrFail(name);
 	}
 
+	public getMany(names: string[]) {
+		return this.api.db.getRepository(DiscordResource).find({
+			where: names.map(name => ({ name }))
+		});
+	}
+
 	public async getId(name: string) {
 		return (await this.get(name))?.discordId;
 	}

--- a/src/controllers/TeamController.ts
+++ b/src/controllers/TeamController.ts
@@ -1,6 +1,7 @@
 import * as auth from '@unicsmcr/hs_auth_client';
 import HackathonAPI from '../HackathonAPI';
 import { Team } from '../entities/Team';
+import WrappedError from '../utils/WrappedError';
 
 export interface APITeam {
 	authId: string;
@@ -50,6 +51,12 @@ export class TeamController {
 			if (error.message !== 'Team not found') throw error;
 		}
 		return null;
+	}
+
+	public async getTeamOrFail(authId: string) {
+		const team = await this.getTeam(authId);
+		if (!team) throw new WrappedError(`Team ${authId} does not exist - is it linked?`);
+		return team;
 	}
 
 	public async putTeam(authId: string) {

--- a/src/controllers/TeamController.ts
+++ b/src/controllers/TeamController.ts
@@ -55,7 +55,7 @@ export class TeamController {
 
 	public async getTeamOrFail(authId: string) {
 		const team = await this.getTeam(authId);
-		if (!team) throw new WrappedError(`Team ${authId} does not exist - is it linked?`);
+		if (!team) throw new Error(`Team ${authId} does not exist - is it linked?`);
 		return team;
 	}
 

--- a/src/controllers/TeamController.ts
+++ b/src/controllers/TeamController.ts
@@ -1,7 +1,6 @@
 import * as auth from '@unicsmcr/hs_auth_client';
 import HackathonAPI from '../HackathonAPI';
 import { Team } from '../entities/Team';
-import WrappedError from '../utils/WrappedError';
 
 export interface APITeam {
 	authId: string;

--- a/src/controllers/UserController.ts
+++ b/src/controllers/UserController.ts
@@ -65,6 +65,12 @@ export class UserController {
 			.find(user => user.authId === authId);
 	}
 
+	public async getAuthUserOrFail(authId: string) {
+		const user = await this.getAuthUser(authId);
+		if (!user) throw new Error(`User ${authId} not found on auth system!`);
+		return user;
+	}
+
 	/**
 	 * Will save a discord <-> hs_auth relationship in users table
 	 * If a relationship exists already involving either the discordId or authId, it will be destroyed.

--- a/src/controllers/discord/ChannelsController.ts
+++ b/src/controllers/discord/ChannelsController.ts
@@ -50,6 +50,7 @@ export class ChannelsController {
 			parentId: hackathon,
 			mutedId
 		};
+		await this.ensure('channel.hackathon.welcome', templates.channels.hackathonWelcome(data));
 		await this.ensure('channel.hackathon.announcements', templates.channels.hackathonAnnouncements(data));
 		await this.ensure('channel.hackathon.events', templates.channels.hackathonEvents(data));
 		await this.ensure('channel.hackathon.twitter', templates.channels.hackathonTwitter(data));

--- a/src/routes/discord/verify.ts
+++ b/src/routes/discord/verify.ts
@@ -21,6 +21,8 @@ export class DiscordOAuth2VerifyRoute implements RouteHandler {
 		const { code, state } = req.query as QueryParams;
 		if (!code || !state) return res.status(400).json({ message: 'Missing query parameters' });
 		await this.api.controllers.discord.oauth2.processOAuth2(code, state);
-		res.json({ message: 'ok' });
+		const welcomeChannelId = await this.api.controllers.discord.resources.getId('channel.hackathon.welcome');
+		const url = `https://discordapp.com/channels/${this.api.options.discord.guildId}/${welcomeChannelId}`;
+		res.json({ message: 'ok', url });
 	}
 }

--- a/src/templates/channels.ts
+++ b/src/templates/channels.ts
@@ -85,6 +85,16 @@ interface HackathonOptions {
 	mutedId: string;
 }
 
+export function hackathonWelcome(options: HackathonOptions): CreateGuildChannelData {
+	return {
+		name: 'welcome',
+		topic: 'Welcome to StudentHack 2020\'s Discord server!',
+		parent_id: options.parentId,
+		permission_overwrites: publicReadonly(options.guildId, options.organiserId),
+		type: ChannelType.TEXT
+	};
+}
+
 export function hackathonAnnouncements(options: HackathonOptions): CreateGuildChannelData {
 	return {
 		name: 'announcements',

--- a/src/utils/WrappedError.ts
+++ b/src/utils/WrappedError.ts
@@ -1,0 +1,12 @@
+// If an error is thrown as an APIError, the error message should be safe to display to the end user
+export default class WrappedError extends Error {
+	public rootError?: Error;
+	public constructor(message: string, rootError?: Error) {
+		super(message);
+		this.name = 'WrappedError';
+		if (rootError) {
+			this.rootError = rootError;
+			this.stack = `Error description: ${message}\n${rootError.stack}`;
+		}
+	}
+}


### PR DESCRIPTION
This PR resolves #3.

Any API errors that now produce an error will also provide the error message in the response.

A successful call to `/api/v1/discord/verify` will now also respond with a `url` parameter in the body, which is a URL to the welcome channel of the Hackathon server.