### PR TITLE
feat: user sync endpoint

### DIFF
--- a/src/controllers/UserController.ts
+++ b/src/controllers/UserController.ts
@@ -60,6 +60,12 @@ export class UserController {
 		}
 	}
 
+	public async getUserOrFail(discordId: string) {
+		const user = await this.getUser(discordId);
+		if (!user) throw new Error(`User ${discordId} is not linked`);
+		return user;
+	}
+
 	public async getAuthUser(authId: string) {
 		return (await auth.getAllUsers(this.api.options.hsAuth.token))
 			.find(user => user.authId === authId);

--- a/src/routes/users/index.ts
+++ b/src/routes/users/index.ts
@@ -1,3 +1,4 @@
 export * from './user';
 export * from './users';
 export * from './userRoles';
+export * from './userSync';

--- a/src/routes/users/userSync.ts
+++ b/src/routes/users/userSync.ts
@@ -1,0 +1,20 @@
+import RouteHandler from '../../RouteHandler';
+import HackathonAPI from '../../HackathonAPI';
+import { Request, Response } from 'express';
+
+export class UserSyncRoute implements RouteHandler {
+	private readonly api: HackathonAPI;
+	public constructor(api: HackathonAPI) {
+		this.api = api;
+	}
+
+	public getRoute() {
+		return '/users/:id/sync';
+	}
+
+	public async put(req: Request, res: Response) {
+		const discordId: string = req.params.id;
+		await this.api.controllers.discord.oauth2.syncMember(discordId);
+		res.json({ message: 'ok' });
+	}
+}


### PR DESCRIPTION
This adds a the sync endpoint to allow users to sync their hs_auth state without having to go to the Hub and click on "Join Discord" again.
