### PR TITLE
refactor: use Auth V2 API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -251,9 +251,9 @@
       }
     },
     "@unicsmcr/hs_auth_client": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@unicsmcr/hs_auth_client/-/hs_auth_client-3.0.1.tgz",
-      "integrity": "sha512-P0XdRPQ4ZQp2dIyKJ+xg4hhrlTI3Q/JEYW9+vk0Z5GYRb6R8gzzJhQtYiMF/VJAgxE4zGu4wKvra9PT9NR0BHw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@unicsmcr/hs_auth_client/-/hs_auth_client-3.1.0.tgz",
+      "integrity": "sha512-MRHBQYamGoMEDyWQ+KcoHQ1WiDVrAYlWWNQWsw9ShKCqhINeKgATXK3vVrT5KGQCu5qWhn2I/HbHpALKHylm9Q==",
       "requires": {
         "axios": "^0.19.2"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -251,9 +251,9 @@
       }
     },
     "@unicsmcr/hs_auth_client": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@unicsmcr/hs_auth_client/-/hs_auth_client-2.0.0.tgz",
-      "integrity": "sha512-9wDRkuNAXCsMw7U36tdt6BPdb7fhliYwVaroIg1PIdoCU9HUrTdGgcx4ZWovydTGokrZANBEoABnFY2HEvFN1g==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@unicsmcr/hs_auth_client/-/hs_auth_client-3.0.1.tgz",
+      "integrity": "sha512-P0XdRPQ4ZQp2dIyKJ+xg4hhrlTI3Q/JEYW9+vk0Z5GYRb6R8gzzJhQtYiMF/VJAgxE4zGu4wKvra9PT9NR0BHw==",
       "requires": {
         "axios": "^0.19.2"
       }

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@spectacles/rest": "^0.8.3",
     "@types/express": "^4.17.6",
     "@types/node-fetch": "^2.5.7",
-    "@unicsmcr/hs_auth_client": "^3.0.1",
+    "@unicsmcr/hs_auth_client": "^3.1.0",
     "axios": "^0.19.2",
     "dotenv": "^8.2.0",
     "express": "^4.17.1",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@spectacles/rest": "^0.8.3",
     "@types/express": "^4.17.6",
     "@types/node-fetch": "^2.5.7",
-    "@unicsmcr/hs_auth_client": "^2.0.0",
+    "@unicsmcr/hs_auth_client": "^3.0.1",
     "axios": "^0.19.2",
     "dotenv": "^8.2.0",
     "express": "^4.17.1",

--- a/src/controllers/TeamController.ts
+++ b/src/controllers/TeamController.ts
@@ -1,6 +1,7 @@
 import * as auth from '@unicsmcr/hs_auth_client';
 import HackathonAPI from '../HackathonAPI';
 import { Team } from '../entities/Team';
+import { authClient } from '../utils/AuthClient';
 
 export interface APITeam {
 	authId: string;
@@ -19,7 +20,7 @@ export class TeamController {
 	public async getTeams() {
 		const [dbTeams, authTeams] = await Promise.all([
 			this.api.db.getRepository(Team).find(),
-			auth.getTeams(this.api.options.hsAuth.token)
+			authClient.getTeams(this.api.options.hsAuth.token)
 		]);
 
 		const linkedIds: Map<string, Team> = new Map();
@@ -40,7 +41,7 @@ export class TeamController {
 	public async getTeam(authId: string) {
 		const [dbTeam, authTeam] = await Promise.all([
 			this.api.db.getRepository(Team).findOneOrFail({ authId }),
-			auth.getTeam(this.api.options.hsAuth.token, authId)
+			authClient.getTeam(this.api.options.hsAuth.token, authId)
 		]);
 		return this.transformAuthTeam(authTeam, dbTeam.teamNumber);
 	}
@@ -55,7 +56,7 @@ export class TeamController {
 	}
 
 	public async putAllTeams() {
-		const teams = await auth.getTeams(this.api.options.hsAuth.token);
+		const teams = await authClient.getTeams(this.api.options.hsAuth.token);
 		for (const team of teams) {
 			await this.putTeam(team.id);
 		}

--- a/src/controllers/UserController.ts
+++ b/src/controllers/UserController.ts
@@ -7,7 +7,6 @@ import { authClient } from '../utils/AuthClient';
 export interface APIUser {
 	authId: string;
 	discordId: string;
-	authLevel: auth.AuthLevel;
 	email: string;
 	name: string;
 	team?: string;
@@ -175,7 +174,6 @@ export class UserController {
 		return {
 			authId: authUser.id,
 			discordId: dbUser.discordId,
-			authLevel: authUser.authLevel,
 			email: authUser.email,
 			name: authUser.name,
 			team: authUser.team,

--- a/src/controllers/UserController.ts
+++ b/src/controllers/UserController.ts
@@ -2,6 +2,7 @@ import * as auth from '@unicsmcr/hs_auth_client';
 import HackathonAPI from '../HackathonAPI';
 import { User } from '../entities/User';
 import { DiscordResource } from '../entities/DiscordResource';
+import { authClient } from '../utils/AuthClient';
 
 export interface APIUser {
 	authId: string;
@@ -23,7 +24,7 @@ export class UserController {
 	public async getUsers() {
 		const [dbUsers, authUsers] = await Promise.all([
 			this.api.db.getRepository(User).find({ relations: ['roles'] }),
-			auth.getUsers(this.api.options.hsAuth.token)
+			authClient.getUsers(this.api.options.hsAuth.token)
 		]);
 
 		const authMap: Map<string, User> = new Map();
@@ -47,7 +48,7 @@ export class UserController {
 				where: { discordId },
 				relations: ['roles']
 			}),
-			auth.getUsers(this.api.options.hsAuth.token)
+			authClient.getUsers(this.api.options.hsAuth.token)
 		]);
 
 		const targetId = dbUser.authId;
@@ -61,7 +62,7 @@ export class UserController {
 	}
 
 	public async getAuthUser(authId: string) {
-		return (await auth.getUsers(this.api.options.hsAuth.token))
+		return (await authClient.getUsers(this.api.options.hsAuth.token))
 			.find(user => user.id === authId);
 	}
 

--- a/src/controllers/UserController.ts
+++ b/src/controllers/UserController.ts
@@ -92,7 +92,7 @@ export class UserController {
 				const newRoles = [...roles];
 				// Now copy over relevant roles from existing relation
 				for (const existingRole of refreshUser.roles) {
-					// Any AuthLevel roles and team roles should be ignored, copy everything else
+					// Any auth roles and team roles should be ignored, copy everything else
 					if (!['role.organiser', 'role.volunteer', 'role.attendee'].includes(existingRole.name) &&
 						!existingRole.name.startsWith('role.teams')) {
 						newRoles.push(existingRole);

--- a/src/controllers/discord/OAuth2Controller.ts
+++ b/src/controllers/discord/OAuth2Controller.ts
@@ -109,7 +109,6 @@ export class OAuth2Controller {
 	}
 
 	private async getAuthRole(user: User): Promise<DiscordResource> {
-		// todo: once the auth client is updated, pass the user's id in as a parameter here.
 		const resources = await authClient.getAuthorizedResources(this.api.options.hsAuth.token, Object.values(AuthRole), user.id);
 
 		if (resources.includes(AuthRole.Organiser)) {

--- a/src/controllers/discord/OAuth2Controller.ts
+++ b/src/controllers/discord/OAuth2Controller.ts
@@ -110,7 +110,7 @@ export class OAuth2Controller {
 
 	private async getAuthRole(user: User): Promise<DiscordResource> {
 		// todo: once the auth client is updated, pass the user's id in as a parameter here.
-		const resources = await authClient.getAuthorizedResources(this.api.options.hsAuth.token, Object.values(AuthRole));
+		const resources = await authClient.getAuthorizedResources(this.api.options.hsAuth.token, Object.values(AuthRole), user.id);
 
 		if (resources.includes(AuthRole.Organiser)) {
 			return this.parent.resources.getOrFail('role.organiser');

--- a/src/utils/AuthClient.ts
+++ b/src/utils/AuthClient.ts
@@ -1,0 +1,5 @@
+import { AuthApi } from '@unicsmcr/hs_auth_client';
+
+const authClient = new AuthApi('hs_discord');
+
+export { authClient };


### PR DESCRIPTION
This performs a minimal update to the HS Discord API allowing it to work with Auth v2 API. The only thing that I can think of that it is currently missing is the sponsors role.